### PR TITLE
#9 Simplify Dockerfile by removing logback configuration.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM openjdk:21
 
-RUN touch /logback.xml
+COPY ./target/registry.jar /app.jar
 
-COPY ./target/registry.jar /registry.jar
-
-ENTRYPOINT ["/usr/bin/java", "-Dlogging.config=file:/logback.xml", "-jar", "/registry.jar"]
+ENTRYPOINT ["/usr/bin/java", "-jar", "/app.jar"]


### PR DESCRIPTION
Removed unnecessary logback configuration and adjusted the path to the application JAR file. This streamlines the Docker image and avoids redundant file handling steps.